### PR TITLE
Make calfram pip installable from GitHub 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "calfram"
+version = "0.1.0"
+description = "Calibration Framework"
+authors = [
+  { name = "Lorenzo Famiglini" }           
+]
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }               
+
+dependencies = [
+  "pandas==2.2.2",
+  "numpy==1.26.4",
+  "matplotlib==3.9.1",
+  "scikit-learn==1.5.1",
+  "ipdb==0.13.13"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["calfram*"]                   
+exclude = ["tests*"]                     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,11 @@ requires-python = ">=3.8"
 license = { text = "MIT" }               
 
 dependencies = [
-  "pandas==2.2.2",
-  "numpy==1.26.4",
-  "matplotlib==3.9.1",
-  "scikit-learn==1.5.1",
-  "ipdb==0.13.13"
+  "pandas^2.2.2",
+  "numpy^1.26.4",
+  "matplotlib^3.9.1",
+  "scikit-learn^1.5.1",
+  "ipdb^0.13.13"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,11 @@ requires-python = ">=3.8"
 license = { text = "MIT" }               
 
 dependencies = [
-  "pandas^2.2.2",
-  "numpy^1.26.4",
-  "matplotlib^3.9.1",
-  "scikit-learn^1.5.1",
-  "ipdb^0.13.13"
+  "pandas~=2.2.2", 
+  "numpy~=1.26.4",
+  "matplotlib~=3.9.1",
+  "scikit-learn~=1.5.1",
+  "ipdb~=0.13.13"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Allows you to pip install this repo's code as a package in python by running:
pip install git+https://github.com/lorenzofamiglini/CalFram.git@main#egg=calfram
