### PR TITLE
Make CalFram pip installable and amend bug where no values are returned.

### DIFF
--- a/calfram/calibration_framework.py
+++ b/calfram/calibration_framework.py
@@ -212,8 +212,8 @@ class CalibrationFramework:
                     below_dist: NDArray[np.float64] = pts_distance_norm[mask_right]
                     up_pts: NDArray[np.float64] = new_pts[1:][mask_left]
                     below_pts: NDArray[np.float64] = new_pts[1:][mask_right]
-                    up_weight: NDArray[np.float64] = bins_dict['binfr'][mask_left] if len(bins_dict['binfr']) > np.sum(mask_left) else np.array([])
-                    below_weight: NDArray[np.float64] = bins_dict['binfr'][mask_right] if len(bins_dict['binfr']) > np.sum(mask_right) else np.array([])
+                    up_weight: NDArray[np.float64] = bins_dict['binfr'][mask_left] if len(bins_dict['binfr']) >= np.sum(mask_left) else np.array([])
+                    below_weight: NDArray[np.float64] = bins_dict['binfr'][mask_right] if len(bins_dict['binfr']) >= np.sum(mask_right) else np.array([])
 
                     # Fix: Safe weighted average calculations
                     if len(bins_dict['binfr']) > 0 and np.sum(bins_dict['binfr']) > 0:
@@ -412,10 +412,11 @@ class CalibrationFramework:
 
     @staticmethod
     def underbelow_line(pts: NDArray[np.float64]) -> List[str]:
-        return ['lie' if idx == 0 else 
+        return [ 
                 'left' if (1 - 0) * (pt[1] - 0) - (pt[0] - 0) * (1 - 0) > 0 else 
                 'right' if (1 - 0) * (pt[1] - 0) - (pt[0] - 0) * (1 - 0) < 0 else 
-                'lie' for idx, pt in enumerate(pts)]
+                'lie' for idx, pt in enumerate(pts)
+                ]
 
     @staticmethod
     def check_idx(pts: NDArray[np.float64]) -> List[int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "calfram"
+version = "0.1.0"
+description = "Calibration Framework"
+authors = [
+  { name = "Lorenzo Famiglini" }           
+]
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }               
+
+dependencies = [
+  "pandas==2.2.2",
+  "numpy==1.26.4",
+  "matplotlib==3.9.1",
+  "scikit-learn==1.5.1",
+  "ipdb==0.13.13"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["calfram*"]                   
+exclude = ["tests*"]                     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,11 @@ requires-python = ">=3.8"
 license = { text = "MIT" }               
 
 dependencies = [
-  "pandas==2.2.2",
-  "numpy==1.26.4",
-  "matplotlib==3.9.1",
-  "scikit-learn==1.5.1",
-  "ipdb==0.13.13"
+  "pandas^2.2.2",
+  "numpy^1.26.4",
+  "matplotlib^3.9.1",
+  "scikit-learn^1.5.1",
+  "ipdb^0.13.13"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,11 @@ requires-python = ">=3.8"
 license = { text = "MIT" }               
 
 dependencies = [
-  "pandas^2.2.2",
-  "numpy^1.26.4",
-  "matplotlib^3.9.1",
-  "scikit-learn^1.5.1",
-  "ipdb^0.13.13"
+  "pandas~=2.2.2", 
+  "numpy~=1.26.4",
+  "matplotlib~=3.9.1",
+  "scikit-learn~=1.5.1",
+  "ipdb~=0.13.13"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The bug seems to appear in heavily skewed classification, when there are 1 or 2 bins. Resulting in no values being returned. 
The fix too underbelow_line amends identifying points as on the line merely for being the first in the list. 
Not so sure what the change to the up/below weights did but the numbers i get are in line with what i expect. 